### PR TITLE
Add dev profile properties to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/target/
 frontend/src/app/api/
+backend/src/main/resources/application-dev.properties
 
 # Created by https://www.toptal.com/developers/gitignore/api/node,java,yarn,macos,linux,windows,intellij,java-web,visualstudiocode,gradle
 # Edit at https://www.toptal.com/developers/gitignore?templates=node,java,yarn,macos,linux,windows,intellij,java-web,visualstudiocode,gradle


### PR DESCRIPTION
The `application-dev.properties` should not be added to git as it contains local settings.