### PR TITLE
🐳 Add Dockerfile and docker-compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+api/node_modules
+api/target
+
+backend/build
+backend/.gradle
+backend/Dockerfile
+
+frontend/dist
+frontend/node_modules
+frontend/Dockerfile

--- a/.idea/IAA.iml
+++ b/.idea/IAA.iml
@@ -7,6 +7,7 @@
       <sourceFolder url="file://$MODULE_DIR$/frontend/src/app/api" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/backend/src/main/java/de/nordakademie/iaa/noodle/api" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/.idea/dataSources" />
+      <excludeFolder url="file://$MODULE_DIR$/frontend/dist" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,13 @@
+{
+    admin off
+    auto_https off
+}
+
+:2020 {
+    @api {
+        path /api*
+    }
+
+    reverse_proxy @api backend:8080
+    reverse_proxy frontend:5000
+}

--- a/README.md
+++ b/README.md
@@ -11,11 +11,25 @@ The application at hand is a survey tool used to plan various meetings
 with multiple participants.
 
 We have divided it into the [frontend](/frontend) and the [backend](backend).
-Installation Instructions can be found 
+Installation Instructions for developing can be found 
 [here for the frontend](#setting-up-the-frontend) and 
 [here for the backend](#setting-up-the-backend).
 
-## Setting up the API
+## Quick Start
+
+To quickly build and run all components you can use Docker. Make sure you have [Docker installed](https://www.docker.com/products/docker-desktop),
+then execute the following instructions inside the project directory:
+
+```shell script
+docker-compose up
+```
+
+On the first run the Docker images are build from the sources. This might take a while depending on your internet connection and processor speed.
+Once everything has started you can visit the application on [localhost:2020](http://localhost:2020). 
+
+## Development setup
+
+### Setting up the API
 
 This project uses an Open-API 3 specification.
 To set up and generate the API access code in the frontend and the `api.yml` for the backend, 
@@ -27,12 +41,12 @@ yarn install
 yarn generate
 ```
 
-## Frontend
+### Frontend
 
 The frontend of the application was built using [Angular](https://angular.io) 
 and [yarn](https://classic.yarnpkg.com/en/).
 
-### Setting up the Frontend
+#### Setting up the Frontend
 
 For a start, you will need 
 [yarn](https://classic.yarnpkg.com/en/docs/install/) and [Angular CLI](https://cli.angular.io).
@@ -48,12 +62,12 @@ yarn install
 ng serve
 ```
 
-## Backend
+### Backend
 
 On the backend, [Spring Boot](https://spring.io/projects/spring-boot) does the heavy lifting.
 The build is done by [Gradle](https://gradle.org).
 
-### Setting up the Backend
+#### Setting up the Backend
 
 You will need a Java15-JDK like 
 [this one](https://adoptopenjdk.net/?variant=openjdk15&jvmVariant=hotspot).
@@ -67,7 +81,7 @@ open a terminal in its root directory and use the following command:
 ./gradlew bootRun
 ```
 
-### Development Profile
+#### Development Profile
 
 When developing the backend in IntelliJ, it's recommended to pass
 it the environment variable `spring_profiles_active=dev` to enable
@@ -77,7 +91,7 @@ in [backend/src/main/resources](backend/src/main/resources) to change
 Properties locally without conflicting with the checked in 
 [application.properties](backend/src/main/resources/application.properties).
 
-### Hibernate Debugging
+#### Hibernate Debugging
 
 In order to see Hibernate's SQL-Queries when debugging, add the
 following to your `application.properties` or, if you have one, your

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,39 @@
+# ----------------------- API builder -----------------------
+
+FROM node:15.0.1-alpine3.10 AS api-builder
+
+WORKDIR /api
+
+# Cache any dependencies
+COPY ./api/package.json ./api/yarn.lock ./
+RUN yarn
+
+# Generate the API
+COPY ./api .
+RUN yarn generate
+
+# ----------------------- Java builder -----------------------
+
+FROM adoptopenjdk:15_36-jdk-openj9-0.22.0-bionic AS java-builder
+
+WORKDIR /project
+
+# Cache gradle installation
+COPY ./backend/build.gradle ./backend/settings.gradle ./backend/gradlew ./backend/
+COPY ./backend/gradle ./backend/gradle
+RUN cd backend && ./gradlew --no-daemon -v || return 0
+
+# Build and bundle the backend jar
+COPY . .
+COPY --from=api-builder /api/target ./api/target
+RUN cd backend && ./gradlew --no-daemon assemble
+
+# ----------------------- Final image -----------------------
+
+FROM adoptopenjdk:15_36-jre-openj9-0.22.0-bionic AS iaa-backend
+
+COPY --from=java-builder /project/backend/build/libs/noodle-*.jar /
+RUN mv /noodle-*.jar /noodle.jar
+
+EXPOSE 8080
+CMD java -jar /noodle.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.8"
+
+services:
+    proxy:
+        image: caddy:2.1.1-alpine
+        ports:
+            - "2020:2020"
+        networks:
+            - services
+            - default
+        volumes:
+            - $PWD/Caddyfile:/etc/caddy/Caddyfile
+    frontend:
+        build:
+            context: .
+            dockerfile: frontend/Dockerfile
+        ports:
+            - "5000:5000"
+        networks:
+            - services
+        depends_on:
+            - backend
+    backend:
+        build:
+            context: .
+            dockerfile: backend/Dockerfile
+        environment:
+            - "SERVER_SERVLET_CONTEXT_PATH=/api"
+        ports:
+            - "8080:8080"
+        networks:
+            - services
+
+networks:
+    services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
         build:
             context: .
             dockerfile: frontend/Dockerfile
-        ports:
-            - "5000:5000"
         networks:
             - services
         depends_on:
@@ -26,8 +24,6 @@ services:
             dockerfile: backend/Dockerfile
         environment:
             - "SERVER_SERVLET_CONTEXT_PATH=/api"
-        ports:
-            - "8080:8080"
         networks:
             - services
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,40 @@
+# ----------------------- API builder -----------------------
+
+FROM node:15.0.1-alpine3.10 AS api-builder
+
+WORKDIR /project/api
+
+# Cache any dependencies
+COPY ./api/package.json ./api/yarn.lock ./
+RUN yarn
+
+# Generate the API
+COPY ./api .
+RUN yarn generate
+
+# ----------------------- Frontend builder -----------------------
+
+FROM node:15.0.1-alpine3.10 AS frontend-builder
+
+WORKDIR /project
+
+# Cache frontend dependencies
+COPY ./frontend/package.json ./frontend/yarn.lock ./frontend/
+RUN cd frontend && yarn
+
+# Build and bundle the frontend
+COPY . .
+COPY --from=api-builder /project/frontend/src/app/api ./frontend/src/app/api
+RUN cd frontend && yarn build
+
+# ----------------------- Final image -----------------------
+
+FROM node:15.0.1-alpine3.10 AS iaa-frontend
+
+WORKDIR /app
+RUN yarn global add serve
+
+COPY --from=frontend-builder /project/frontend/dist/frontend/* /app/
+
+EXPOSE 5000
+CMD serve


### PR DESCRIPTION
This PR adds `Dockerfiles` for both the frontend and the backend which are individually fully functional. Additionally, a `docker-compose.yml` has been added which isolates the individual services in their own network and provides a reverse proxy to make everything available on a single endpoint.