### PR TITLE
🤡 Switch to modified code generator and add mock data

### DIFF
--- a/api/mockData/activateUser.json
+++ b/api/mockData/activateUser.json
@@ -1,0 +1,5 @@
+{
+    "id": 42,
+    "email": "max@mustermann.de",
+    "name": "Max Mustermann"
+}

--- a/api/mockData/authenticate.json
+++ b/api/mockData/authenticate.json
@@ -1,0 +1,5 @@
+{
+    "email": "max@mustermann.de",
+    "name": "Max Mustermann",
+    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+}

--- a/api/mockData/closeSurvey.json
+++ b/api/mockData/closeSurvey.json
@@ -1,0 +1,1 @@
+common/survey.json

--- a/api/mockData/common/response.json
+++ b/api/mockData/common/response.json
@@ -1,0 +1,22 @@
+{
+    "isEditable": true,
+    "responses": [
+        {
+            "timeslotID": 0,
+            "value": false
+        },
+        {
+            "timeslotID": 1,
+            "value": true
+        },
+        {
+            "timeslotID": 1,
+            "value": true
+        }
+    ],
+    "surveyID": 42,
+    "user": {
+        "id": 42,
+        "name": "Max Mustermann"
+    }
+}

--- a/api/mockData/common/survey.json
+++ b/api/mockData/common/survey.json
@@ -1,0 +1,26 @@
+{
+    "creator": {
+        "id": 42,
+        "name": "Max Mustermann"
+    },
+    "isClosed": false,
+    "title": "Game night",
+    "description": "Veniam aut reprehenderit fugiat nisi ut. Libero nostrum dolores voluptatem enim sed explicabo. Non in sed minus. Optio voluptatem qui et eaque a sit perferendis dolores. Ab ratione dicta excepturi explicabo quia quasi. Distinctio fugiat nesciunt cumque nobis et et et qui.",
+    "timeslots": [
+        {
+            "id": 0,
+            "start": "2019-08-24T14:15:00Z",
+            "end": "2019-08-24T14:30:00Z"
+        },
+        {
+            "id": 1,
+            "start": "2019-08-24T14:30:00Z",
+            "end": "2019-08-24T14:45:00Z"
+        },
+        {
+            "id": 2,
+            "start": "2019-08-24T14:45:00Z",
+            "end": "2019-08-24T15:00:00Z"
+        }
+    ]
+}

--- a/api/mockData/createResponse.json
+++ b/api/mockData/createResponse.json
@@ -1,0 +1,1 @@
+common/response.json

--- a/api/mockData/createSurvey.json
+++ b/api/mockData/createSurvey.json
@@ -1,0 +1,27 @@
+{
+    "id": 42,
+    "creator": {
+        "id": 42,
+        "name": "Max Mustermann"
+    },
+    "isClosed": false,
+    "title": "Game night",
+    "description": "Veniam aut reprehenderit fugiat nisi ut. Libero nostrum dolores voluptatem enim sed explicabo. Non in sed minus. Optio voluptatem qui et eaque a sit perferendis dolores. Ab ratione dicta excepturi explicabo quia quasi. Distinctio fugiat nesciunt cumque nobis et et et qui.",
+    "timeslots": [
+        {
+            "id": 0,
+            "start": "2019-08-24T14:15:00Z",
+            "end": "2019-08-24T14:30:00Z"
+        },
+        {
+            "id": 1,
+            "start": "2019-08-24T14:30:00Z",
+            "end": "2019-08-24T14:45:00Z"
+        },
+        {
+            "id": 2,
+            "start": "2019-08-24T14:45:00Z",
+            "end": "2019-08-24T15:00:00Z"
+        }
+    ]
+}

--- a/api/mockData/createUser.json
+++ b/api/mockData/createUser.json
@@ -1,0 +1,5 @@
+{
+    "id": 42,
+    "email": "max@mustermann.de",
+    "name": "Max Mustermann"
+}

--- a/api/mockData/deleteSurvey.json
+++ b/api/mockData/deleteSurvey.json
@@ -1,0 +1,1 @@
+common/survey.json

--- a/api/mockData/queryResponse.json
+++ b/api/mockData/queryResponse.json
@@ -1,0 +1,1 @@
+common/response.json

--- a/api/mockData/querySurvey.json
+++ b/api/mockData/querySurvey.json
@@ -1,0 +1,94 @@
+{
+    "creator": {
+        "id": 42,
+        "name": "Max Mustermann"
+    },
+    "isClosed": false,
+    "title": "Game night",
+    "description": "Veniam aut reprehenderit fugiat nisi ut. Libero nostrum dolores voluptatem enim sed explicabo. Non in sed minus. Optio voluptatem qui et eaque a sit perferendis dolores. Ab ratione dicta excepturi explicabo quia quasi. Distinctio fugiat nesciunt cumque nobis et et et qui.",
+    "timeslots": [
+        {
+            "id": 0,
+            "start": "2019-08-24T14:15:00Z",
+            "end": "2019-08-24T14:30:00Z"
+        },
+        {
+            "id": 1,
+            "start": "2019-08-24T14:30:00Z",
+            "end": "2019-08-24T14:45:00Z"
+        },
+        {
+            "id": 2,
+            "start": "2019-08-24T14:45:00Z",
+            "end": "2019-08-24T15:00:00Z"
+        }
+    ],
+    "responses": [
+        {
+            "isEditable": true,
+            "surveyID": 42,
+            "user": {
+                "id": 42,
+                "name": "Max Mustermann"
+            },
+            "responses": [
+                {
+                    "timeslotID": 0,
+                    "value": false
+                },
+                {
+                    "timeslotID": 1,
+                    "value": true
+                },
+                {
+                    "timeslotID": 2,
+                    "value": false
+                }
+            ]
+        },
+        {
+            "isEditable": false,
+            "surveyID": 42,
+            "user": {
+                "id": 43,
+                "name": "Klaus Meier"
+            },
+            "responses": [
+                {
+                    "timeslotID": 0,
+                    "value": true
+                },
+                {
+                    "timeslotID": 1,
+                    "value": true
+                },
+                {
+                    "timeslotID": 2,
+                    "value": false
+                }
+            ]
+        },
+        {
+            "isEditable": false,
+            "surveyID": 42,
+            "user": {
+                "id": 44,
+                "name": "Peter Schlosser"
+            },
+            "responses": [
+                {
+                    "timeslotID": 0,
+                    "value": true
+                },
+                {
+                    "timeslotID": 1,
+                    "value": true
+                },
+                {
+                    "timeslotID": 2,
+                    "value": true
+                }
+            ]
+        }
+    ]
+}

--- a/api/mockData/querySurveys.json
+++ b/api/mockData/querySurveys.json
@@ -1,0 +1,9 @@
+{
+    "surveys": [
+        {
+            "id": 42,
+            "title": "Game night",
+            "participantCount": 2
+        }
+    ]
+}

--- a/api/mockData/requestRegistrationEmail.json
+++ b/api/mockData/requestRegistrationEmail.json
@@ -1,0 +1,4 @@
+{
+    "email": "max@mustermann.de",
+    "name": "Max Mustermann"
+}

--- a/api/mockData/updateResponse.json
+++ b/api/mockData/updateResponse.json
@@ -1,0 +1,1 @@
+common/response.json

--- a/api/mockData/updateSurvey.json
+++ b/api/mockData/updateSurvey.json
@@ -1,0 +1,1 @@
+common/survey.json

--- a/api/package.json
+++ b/api/package.json
@@ -16,7 +16,7 @@
     "ajv": "4.11.8",
     "core-js": "^3.1.4",
     "fs-extra": "^9.0.1",
-    "ng-openapi-mock-gen": "^0.13.3",
+    "ng-openapi-mock-gen": "^0.13.4",
     "react": ">=16.3.0",
     "react-dom": ">=16.3.0",
     "react-is": ">=16.8.0",

--- a/api/package.json
+++ b/api/package.json
@@ -8,7 +8,7 @@
     "generate": "yarn generate-spec && yarn generate-docs && yarn generate-frontend",
     "generate-spec": "spot generate -c specification/api.ts -g openapi3 -l yaml -o target/ && ts-node --skip-project postprocess.ts",
     "generate-docs": "redoc-cli bundle target/api.yml -o target/api.html --title 'API Documentation' --options.pathInMiddlePanel=true",
-    "generate-frontend": "ng-openapi-gen --input target/api.yml --output ../frontend/src/app/api"
+    "generate-frontend": "ng-openapi-gen --input target/api.yml --output ../frontend/src/app/api --mockDataDirectory mockData"
   },
   "dependencies": {
     "@airtasker/spot": "^1.2.0",
@@ -16,7 +16,7 @@
     "ajv": "4.11.8",
     "core-js": "^3.1.4",
     "fs-extra": "^9.0.1",
-    "ng-openapi-gen": "^0.12.1",
+    "ng-openapi-mock-gen": "^0.13.3",
     "react": ">=16.3.0",
     "react-dom": ">=16.3.0",
     "react-is": ">=16.8.0",

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1921,10 +1921,10 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-ng-openapi-gen@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/ng-openapi-gen/-/ng-openapi-gen-0.12.1.tgz#1a4d61df7bd8e6dd3997034e9eee1e4836214414"
-  integrity sha512-lfBYSWLrFzKvmTyY0Vqzam4leodhTE4jR2nAQ6J3h7jNoqUIxMRMUqXKXSzwanHUQM36lh4cxiJrIqcmQ+5XpA==
+ng-openapi-mock-gen@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/ng-openapi-mock-gen/-/ng-openapi-mock-gen-0.13.3.tgz#3312cc18fbee16920ccac0f61be063f01eb1cf68"
+  integrity sha512-i2yhypCY8jnK6Jx8II1Lx0nJYqROJslXBNvoNLw6OX8AO4OTFRX/vW3kBL3OFQXy1Rd30/EooWgDFpEn5Xq1jg==
   dependencies:
     "@loopback/openapi-v3-types" "^1.2.1"
     "@types/argparse" "^1.0.38"

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1921,10 +1921,10 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-ng-openapi-mock-gen@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/ng-openapi-mock-gen/-/ng-openapi-mock-gen-0.13.3.tgz#3312cc18fbee16920ccac0f61be063f01eb1cf68"
-  integrity sha512-i2yhypCY8jnK6Jx8II1Lx0nJYqROJslXBNvoNLw6OX8AO4OTFRX/vW3kBL3OFQXy1Rd30/EooWgDFpEn5Xq1jg==
+ng-openapi-mock-gen@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/ng-openapi-mock-gen/-/ng-openapi-mock-gen-0.13.4.tgz#5aac34a15ee66ebdc7c0657c78b392823c80d1b7"
+  integrity sha512-PtBw1BG+h5X+TacahvbUCkSl1ao510JYYOrfEiyVz8J2x0OYvMyJWtiGF9If2jjZVab4YksuZLgxFE88ZiXGfA==
   dependencies:
     "@loopback/openapi-v3-types" "^1.2.1"
     "@types/argparse" "^1.0.38"


### PR DESCRIPTION
This PR changes the `ng-openapi-gen` code generator dependency to a modified version which is [published on npm](https://www.npmjs.com/package/ng-openapi-mock-gen) and the modified source code is [available on GitHub](https://github.com/TilBlechschmidt/ng-openapi-gen).

It also adds mocked data to a subfolder of the `api/` directory.