### PR TITLE
🔧 Disallow console.log and run linter in pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,9 @@ jobs:
             - name: Install frontend dependencies
               working-directory: ./frontend
               run: yarn --frozen-lockfile
+            - name: Lint frontend
+              working-directory: ./frontend
+              run: yarn lint
             - name: Build frontend
               working-directory: ./frontend
               run: yarn build

--- a/frontend/tslint.json
+++ b/frontend/tslint.json
@@ -46,6 +46,7 @@
     "no-any": true,
     "no-console": [
       true,
+      "log",
       "debug",
       "info",
       "time",


### PR DESCRIPTION
A small change which tweaks the frontend linter in response to PR #12 which had a multitude of `console.log` statements. This is now disallowed. Additionally, the pipeline has been adjusted to enforce all linter settings.