### PR TITLE
🚸Change localStorage for sessionStorage

### DIFF
--- a/frontend/src/app/authentication/service/token.service.ts
+++ b/frontend/src/app/authentication/service/token.service.ts
@@ -6,22 +6,24 @@ import {Jwt} from '../../api/models/jwt';
 })
 export class TokenService {
 
+    private static storage = sessionStorage;
+
     constructor() {
     }
 
     getToken(): Jwt | null {
-        return localStorage.getItem('jwt');
+        return TokenService.storage.getItem('jwt');
     }
 
     isAuthenticated(): boolean {
-        return localStorage.getItem('jwt') != null;
+        return TokenService.storage.getItem('jwt') != null;
     }
 
     deleteToken(): void {
-        localStorage.removeItem('jwt');
+        TokenService.storage.removeItem('jwt');
     }
 
     setToken(token: Jwt): void {
-        localStorage.setItem('jwt', token);
+        TokenService.storage.setItem('jwt', token);
     }
 }


### PR DESCRIPTION
This prevents the login token from being used across browser tabs and allows clean integration of multi-tab logins with different users.